### PR TITLE
Fix incoming transactions retrieval

### DIFF
--- a/src/main/java/com/example/demo/entities/Firm.java
+++ b/src/main/java/com/example/demo/entities/Firm.java
@@ -32,7 +32,11 @@ public class Firm implements Serializable {
     @Property("firm_type")
     private String firmType;
 
-    @Relationship(type = "Transaction", direction = Relationship.Direction.OUTGOING)
+    // We want to load both incoming and outgoing transactions when fetching a firm
+    // to be able to compute transaction direction later in the service layer.
+    // Using UNDIRECTED ensures Spring Data Neo4j retrieves relationships of
+    // either direction.
+    @Relationship(type = "Transaction", direction = Relationship.Direction.UNDIRECTED)
     @JsonManagedReference
 
     private List<Transaction> transactions;

--- a/src/main/java/com/example/demo/repositories/FirmRepository.java
+++ b/src/main/java/com/example/demo/repositories/FirmRepository.java
@@ -16,9 +16,12 @@ public interface FirmRepository extends Neo4jRepository<Firm, Long> {
     // Méthode pour trouver une entreprise par son firmId
     @Query("MATCH (f:Firm) WHERE f.firm_id = $firmId RETURN f")
     Optional<Firm> findByFirmId(Long firmId);
+    // Retrieve both incoming and outgoing transactions related to the firm.
+    // Using an undirected pattern ensures transactions are loaded regardless of
+    // their direction so that the service layer can determine INCOMING or OUTGOING.
     @Query("MATCH (f:Firm {firm_id: $firmId}) " +
-            "OPTIONAL MATCH (o:Firm)-[tIn:Transaction]->(f) " +
-            "RETURN f, tIn, o")
+            "OPTIONAL MATCH (f)-[t:Transaction]-(o:Firm) " +
+            "RETURN f, t, o")
     Optional<Firm> findByIdWithTransactions(@Param("firmId") Long firmId);
 
     List<Firm> findByFirmName(String firmName);


### PR DESCRIPTION
## Summary
- include incoming transactions in `FirmRepository.findByIdWithTransactions`
- load firm transactions in both directions

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ec458cfe083278dd80559fab68b97